### PR TITLE
fix: show nft site

### DIFF
--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -38,7 +38,7 @@ const App = () => {
         connectedContract.on('NewEpicNFTMinted', (from, tokenId) => {
           console.log(from, tokenId.toNumber());
           alert(
-            `あなたのウォレットに NFT を送信しました。OpenSea に表示されるまで最大で10分かかることがあります。NFT へのリンクはこちらです: https://testnets.opensea.io/assets/${CONTRACT_ADDRESS}/${tokenId.toNumber()}`,
+            `あなたのウォレットに NFT を送信しました。gemcase に表示されるまで数分かかることがあります。NFT へのリンクはこちらです: https://gemcase.vercel.app/view/evm/sepolia/${CONTRACT_ADDRESS}/${tokenId.toNumber()}`,
           );
         });
 


### PR DESCRIPTION
## 変更内容
NFTを表示するサイトをopenseaからgemcaseに変更しました。

## 背景
[マークダウンの更新](https://github.com/unchain-tech/UNCHAIN-projects/pull/344)に合わせて見本コードも更新しました。
